### PR TITLE
Issue #41: Fix block media refresh after edition

### DIFF
--- a/Block/BaseModelBlockService.php
+++ b/Block/BaseModelBlockService.php
@@ -128,7 +128,12 @@ abstract class BaseModelBlockService extends BaseBlockService implements Contain
             $model = $block->getSetting($fieldName, null);
             if ($model) {
                 $modelAdmin = $this->getModelAdmin($adminCode);
-                $model = $modelAdmin->getModelManager()->find($modelAdmin->getClass(), $model, $block->getLocale());
+                $modelClass = $modelAdmin->getClass();
+
+                // if model is not already load, do it
+                if (!$model instanceof $modelClass) {
+                    $model = $modelAdmin->getModelManager()->find($modelAdmin->getClass(), $model, $block->getLocale());
+                }
             }
             $block->setSetting($fieldName, $model);
         }
@@ -136,7 +141,12 @@ abstract class BaseModelBlockService extends BaseBlockService implements Contain
             $model = $block->getSetting($fieldName, null);
             if ($model) {
                 $modelAdmin = $this->getModelAdmin($adminCode);
-                $model = $modelAdmin->getModelManager()->getDocumentManager()->findTranslation($modelAdmin->getClass(), $model, $block->getLocale());
+                $modelClass = $modelAdmin->getClass();
+
+                // if model is not already load, do it
+                if (!$model instanceof $modelClass) {
+                    $model = $modelAdmin->getModelManager()->getDocumentManager()->findTranslation($modelAdmin->getClass(), $model, $block->getLocale());
+                }
             }
             $block->setSetting($fieldName, $model);
         }


### PR DESCRIPTION
After editing, the BlockController::renderAction() is called to display it and use the BlockRenderer::render() method to do it.
At this time, the block setting media is already loaded, but the BlockRenderer call PrestaBaseModelBlockService::load($block) which try to reload it and fail.
