### PR TITLE
Fix add page dialog by pressing submit with enter button

### DIFF
--- a/Resources/public/admin/js/cms.js
+++ b/Resources/public/admin/js/cms.js
@@ -213,6 +213,10 @@ var CMSContent = function() {
 
             $('#modal-content').load(url, function() {
                 $('#modal-content div.form-actions').remove();
+                $('#modal-content form').on('submit', function(e) {
+                    e.preventDefault();
+                    CMSContent.submitModalForm();
+                });
                 $('#modal-loader').hide();
                 $('#modal-content').show();
             });


### PR DESCRIPTION
Pressing enter on the add a page dialog submits to a new page rather than using ajax
