### PR TITLE
Replacing DIRECTORY_SEPARATOR with PHPCR seperator '/' because DIRECTORY...

### DIFF
--- a/Doctrine/Phpcr/Website.php
+++ b/Doctrine/Phpcr/Website.php
@@ -52,7 +52,7 @@ class Website extends WebsiteModel implements TranslatableInterface
      */
     public function getRoutePrefix()
     {
-        return $this->getPath() . DIRECTORY_SEPARATOR . self::ROUTE_PREFIX . DIRECTORY_SEPARATOR . $this->getLocale();
+        return $this->getPath() . '/' . self::ROUTE_PREFIX . '/' . $this->getLocale();
     }
 
     /**
@@ -60,7 +60,7 @@ class Website extends WebsiteModel implements TranslatableInterface
      */
     public function getMenuRoot()
     {
-        return $this->getPath() . DIRECTORY_SEPARATOR . self::MENU_PREFIX;
+        return $this->getPath() . '/' . self::MENU_PREFIX;
     }
 
     /**
@@ -68,6 +68,6 @@ class Website extends WebsiteModel implements TranslatableInterface
      */
     public function getPageRoot()
     {
-        return $this->getPath() . DIRECTORY_SEPARATOR . self::PAGE_PREFIX;
+        return $this->getPath() . '/' . self::PAGE_PREFIX;
     }
 }

--- a/Factory/ThemeFactory.php
+++ b/Factory/ThemeFactory.php
@@ -55,7 +55,7 @@ class ThemeFactory extends AbstractModelFactory implements ModelFactoryInterface
             $zones = array();
             $themeNode = $this->getObjectManager()->findTranslation(
                 $this->modelClassName,
-                $website->getId() . DIRECTORY_SEPARATOR . 'theme' . DIRECTORY_SEPARATOR . $configuration['name'],
+                $website->getId() . '/' . 'theme' . '/' . $configuration['name'],
                 $website->getLocale()
             );
 

--- a/Tests/Resources/DataFixtures/Phpcr/LoadWebsite.php
+++ b/Tests/Resources/DataFixtures/Phpcr/LoadWebsite.php
@@ -28,14 +28,14 @@ class LoadWebsite extends BaseWebsiteFixture
     {
         // Get the base path name to use from the configuration
         $session = $manager->getPhpcrSession();
-        $basePath = DIRECTORY_SEPARATOR . Website::WEBSITE_PREFIX;
+        $basePath = '/' . Website::WEBSITE_PREFIX;
 
         // Create the path in the repository
         NodeHelper::createPath($session, $basePath);
 
         $this->getFactory()->create(
             array(
-                'path' => $basePath . DIRECTORY_SEPARATOR . 'sandbox',
+                'path' => $basePath . '/' . 'sandbox',
                 'name' => 'sandbox',
                 'available_locales' => array('fr', 'en'),
                 'default_locale' => 'fr',


### PR DESCRIPTION
..._SEPARATOR in windows is '\'

| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? |  |
| Fixed tickets |  |
| License | MIT |
| Doc PR |  |
